### PR TITLE
Manage versions with plugin bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.13</version>
+		<version>4.16</version>
 		<relativePath />
 	</parent>
 	<groupId>de.peass</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>structs</artifactId>
-			<version>1.20</version>
 		</dependency>
 
 		<dependency>
@@ -76,43 +75,36 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-step-api</artifactId>
-			<version>2.23</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-cps</artifactId>
-			<version>2.85</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-job</artifactId>
-			<version>2.40</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-basic-steps</artifactId>
-			<version>2.22</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-durable-task-step</artifactId>
-			<version>2.36</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-api</artifactId>
-			<version>2.40</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-support</artifactId>
-			<version>3.6</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -134,15 +126,20 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+                                <groupId>io.jenkins.tools.bom</groupId>
+                                <artifactId>bom-2.263.x</artifactId>
+                                <version>23</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.jenkins-ci.plugins</groupId>
 				<artifactId>script-security</artifactId>
-				<version>1.75</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.jenkins-ci.plugins</groupId>
 				<artifactId>scm-api</artifactId>
-				<version>2.6.4</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
## Use Jenkins plugin bom to manage versions

The Jenkins plugin bill of materials can reduce the version management
challenges for Jenkins components.

- Manage dependencies with plugin bom
- Use latest parent pom 4.16
